### PR TITLE
[dart_lsc] Prepare for 1.0.0 version of sensors and package_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1
+
+* Prepare for 1.0.0 version of sensors and package_info. ([dart_lsc](http://github.com/amirh/dart_lsc))
+
 ## 0.2.0
 
 * fix bugs.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_easy
 description: A common Flutter package.
-version: 0.2.0
+version: 0.2.1
 author: OctMon <octmon@qq.com>
 homepage: https://github.com/OctMon/flutter_easy
 
@@ -49,7 +49,7 @@ dependencies:
   # pub: https://pub.dev/packages/package_info
   # git: https://github.com/flutter/plugins/tree/master/packages/package_info
   # ———————————————————————————————————————————————————————————————————————————————
-  package_info: ^0.4.0+14
+  package_info: '>=0.4.0+14 <2.0.0'
   # ===============================================================================
 
   # ===============================================================================


### PR DESCRIPTION
This should be a safe change, for more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0

This change was auto generated by [dart_lsc](https://github.com/amirh/dart_lsc).